### PR TITLE
Update Dockerfile and dev-workflow.yaml for base64

### DIFF
--- a/.github/workflows/dev-workflow.yaml
+++ b/.github/workflows/dev-workflow.yaml
@@ -69,8 +69,8 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_ID  }}:latest
           build-args: |
-            ID_RSA=${{ secrets.ID_RSA_DEV }}
-            KNOWN_HOSTS=${{ secrets.KNOWN_HOSTS_DEV }}
+            ID_RSA=${{ secrets.ID_RSA_DEV_BASE_64 }}
+            KNOWN_HOSTS=${{ secrets.KNOWN_HOSTS_DEV_BASE_64 }}
           
   terraform_apply:
     name: terraform apply 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,15 @@ COPY pom.xml /home/gis
 
 RUN mvn -f /home/gis/pom.xml clean package -Dmaven.wagon.http.ssl.allowall=true -Dmaven.wagon.http.ssl.insecure=true
 
+# the two lines below can't be used in the github workflow because the files don't exist
+# COPY id_rsa_DEV /home/gfadmin/.ssh/id_rsa
+# COPY known_hosts /home/gfadmin/.ssh/known_hosts
+
+# use these five lines instead to pull the keys from github secrets
 ARG ID_RSA
 ARG KNOWN_HOSTS
-RUN echo $ID_RSA > /home/gfadmin/.ssh/id_rsa
-RUN echo $KNOWN_HOSTS > /home/gfadmin/.ssh/known_hosts
+RUN echo $ID_RSA | base64 -d > /home/gfadmin/.ssh/id_rsa
+RUN echo $KNOWN_HOSTS | base64 -d > /home/gfadmin/.ssh/known_hosts
 RUN chmod 640 /home/gfadmin/.ssh/id_rsa /home/gfadmin/.ssh/known_hosts
 
 FROM payara/server-full:5.2022.4-jdk11

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,12 @@ COPY pom.xml /home/gis
 RUN mvn -f /home/gis/pom.xml clean package -Dmaven.wagon.http.ssl.allowall=true -Dmaven.wagon.http.ssl.insecure=true
 
 # the two lines below can't be used in the github workflow because the files don't exist
+# uncomment them for local development, but leave them commented in the repo
 # COPY id_rsa_DEV /home/gfadmin/.ssh/id_rsa
 # COPY known_hosts /home/gfadmin/.ssh/known_hosts
 
-# use these five lines instead to pull the keys from github secrets
+# use these five lines instead to get the keys from build args
+# the github workflow needs these lines, comment them out for local development
 ARG ID_RSA
 ARG KNOWN_HOSTS
 RUN echo $ID_RSA | base64 -d > /home/gfadmin/.ssh/id_rsa


### PR DESCRIPTION
Secrets stored as GitHub Secrets can be passed as build args to a Docker build. However, they must not contain any newlines or other special characters. These changes use base64-encoded versions of two secrets and decode them in the Dockerfile, ensuring that the secrets are properly passed to the Docker build.