### PR TITLE
Add functionality to grab file hosts from secrets

### DIFF
--- a/GIS-ear/src/main/application/META-INF/glassfish-resources.xml
+++ b/GIS-ear/src/main/application/META-INF/glassfish-resources.xml
@@ -14,10 +14,10 @@
         <property value="GIS Dev Data load Summary" name="emailSubject"/>
         <property value="gisd" name="fedFileHostUserId"/>
         <property value="/" name="fedFileLocation"/>
-        <property value="***" name="fedFilehost"/>
+        <property value="${ENV=FED_FILE_SERVER}" name="fedFilehost"/>
         <property value="HARGISUser" name="harsFileHostUserId"/>
         <property value="/dev/" name="harsFileUploadLocation"/>
-        <property value="***" name="harsFilehost"/>
+        <property value="${ENV=HARS_FILE_SERVER}" name="harsFilehost"/>
         <property value="***" name="mailFrom"/>
         <property value="***" name="mailTo"/>
         <property value="true" name="run-batch-job"/>

--- a/GIS-war/src/main/java/giswar/batch/BatchTaskImpl.java
+++ b/GIS-war/src/main/java/giswar/batch/BatchTaskImpl.java
@@ -76,24 +76,10 @@ public class BatchTaskImpl extends Task implements IBatchTask {
         String bufferSize = (String) config.get(BatchConstants.BUFFER_SIZE);
         int dbBatchSize = Integer.parseInt((String) config.get(BatchConstants.DB_BATCH_SIZE));
 
-        // Check if the host address property is a reference to an environment variable
-        // of the form ${ENV=VARIABLE_NAME} (after spaces are removed)
-        host = host.replace(" ", "");
-        if (host.startsWith("${ENV=")) {
-            host = System.getenv(host.substring(6, host.length() - 1));
-        }
-
         IData fedDs = new SFTPDatasource(host, user, privateKeyPath, bufferSize, knownHostsFile);
 
         host = (String) config.get(BatchConstants.HARS_FILE_HOST);
         user = (String) config.get(BatchConstants.HARS_FILE_HOST_USER_ID);
-
-        // Check if the host address property is a reference to an environment variable
-        // of the form ${ENV=VARIABLE_NAME} (after spaces are removed)
-        host = host.replace(" ", "");
-        if (host.startsWith("${ENV=")) {
-            host = System.getenv(host.substring(6, host.length() - 1));
-        }
 
         IData harsDS = new SFTPDatasource(host, user, privateKeyPath, bufferSize, knownHostsFile);
 

--- a/GIS-war/src/main/java/giswar/batch/BatchTaskImpl.java
+++ b/GIS-war/src/main/java/giswar/batch/BatchTaskImpl.java
@@ -76,10 +76,24 @@ public class BatchTaskImpl extends Task implements IBatchTask {
         String bufferSize = (String) config.get(BatchConstants.BUFFER_SIZE);
         int dbBatchSize = Integer.parseInt((String) config.get(BatchConstants.DB_BATCH_SIZE));
 
+        // Check if the host address property is a reference to an environment variable
+        // of the form ${ENV=VARIABLE_NAME} (after spaces are removed)
+        host = host.replace(" ", "");
+        if (host.startsWith("${ENV=")) {
+            host = System.getenv(host.substring(6, host.length() - 1));
+        }
+
         IData fedDs = new SFTPDatasource(host, user, privateKeyPath, bufferSize, knownHostsFile);
 
         host = (String) config.get(BatchConstants.HARS_FILE_HOST);
         user = (String) config.get(BatchConstants.HARS_FILE_HOST_USER_ID);
+
+        // Check if the host address property is a reference to an environment variable
+        // of the form ${ENV=VARIABLE_NAME} (after spaces are removed)
+        host = host.replace(" ", "");
+        if (host.startsWith("${ENV=")) {
+            host = System.getenv(host.substring(6, host.length() - 1));
+        }
 
         IData harsDS = new SFTPDatasource(host, user, privateKeyPath, bufferSize, knownHostsFile);
 

--- a/GIS-war/src/main/java/giswar/batch/EmailComponent.java
+++ b/GIS-war/src/main/java/giswar/batch/EmailComponent.java
@@ -62,13 +62,6 @@ public class EmailComponent implements IBatchComponent {
         boolean isCloudDeployed = Boolean.valueOf((String) context.getProperty(BatchConstants.IS_CLOUD_DEPLOYED));
 
         String apiURL = (String) context.getProperty(BatchConstants.AWS_API_URL);
-        apiURL = apiURL.replace(" ", "");
-
-        // Check if the api url property is a reference to an environment variable
-        // of the form ${ENV=VARIABLE_NAME} (after spaces are removed)
-        if (apiURL.startsWith("${ENV=")) {
-            apiURL = System.getenv(apiURL.substring(6, apiURL.length() - 1));
-        }
 
         boolean success = false;
         String from = (String) context.getProperty(BatchConstants.MAIL_FROM);

--- a/GIS-war/src/main/java/giswar/listener/StartupListener.java
+++ b/GIS-war/src/main/java/giswar/listener/StartupListener.java
@@ -27,6 +27,18 @@ public class StartupListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent sce) {
 
+        for (String property : batchProperties.stringPropertyNames()) {
+            String value = batchProperties.getProperty(property);
+
+            // Check if the property contains a reference to an environment
+            // variable of the form ${ENV=VARIABLE_NAME}
+            value = value.replace(" ", "");
+            if (value.startsWith("${ENV=")) {
+                value = System.getenv(value.substring(6, value.length() - 1));
+                batchProperties.setProperty(property, value);
+            }
+        }
+
         try {
             batchJobAutoStarter = new BatchJobAutoStarter(ds, batchProperties);
             

--- a/GIS-war/src/main/java/giswar/listener/StartupListener.java
+++ b/GIS-war/src/main/java/giswar/listener/StartupListener.java
@@ -16,6 +16,9 @@ import java.util.Properties;
  */
 public class StartupListener implements ServletContextListener {
 
+    public static final String ENV_PREFIX = "${ENV=";
+    public static final String ENV_SUFFIX = "}";
+
     @Resource(lookup = "java:app/jdbc/gis")
     private DataSource ds;
 
@@ -33,8 +36,8 @@ public class StartupListener implements ServletContextListener {
             // Check if the property contains a reference to an environment
             // variable of the form ${ENV=VARIABLE_NAME}
             value = value.replace(" ", "");
-            if (value.startsWith("${ENV=")) {
-                value = System.getenv(value.substring(6, value.length() - 1));
+            if (value.startsWith(ENV_PREFIX) && value.endsWith(ENV_SUFFIX)) {
+                value = System.getenv(value.substring(ENV_PREFIX.length(), value.length() - ENV_SUFFIX.length()));
                 batchProperties.setProperty(property, value);
             }
         }

--- a/Infrastructure/fargate.tf
+++ b/Infrastructure/fargate.tf
@@ -59,7 +59,11 @@ resource "aws_ecs_task_definition" "gis_td" {
          {"name": "PROVIDER_URI",
          "valueFrom": "${aws_secretsmanager_secret_version.gis_provider_uri.arn}"},
          {"name": "AWS_API_URL",
-         "valueFrom": "${aws_secretsmanager_secret_version.gis_api_uri.arn}"}
+         "valueFrom": "${aws_secretsmanager_secret_version.gis_api_uri.arn}"},
+         {"name": "FED_FILE_HOST",
+         "valueFrom": "${aws_secretsmanager_secret_version.gis_fed_file_host.arn}"},
+         {"name": "HARS_FILE_HOST",
+         "valueFrom": "${aws_secretsmanager_secret_version.gis_hars_file_host.arn}"}
       ]
       environment = [
         {"name": "XMX_DEV",

--- a/Infrastructure/secretsmanager.tf
+++ b/Infrastructure/secretsmanager.tf
@@ -32,6 +32,16 @@ resource "aws_secretsmanager_secret_version" "gis_api_uri" {
   secret_string = "changeme"
 }
 
+resource "aws_secretsmanager_secret_version" "gis_fed_file_host" {
+  secret_id     = aws_secretsmanager_secret.gis_fed_file_host.id
+  secret_string = "changeme"
+}
+
+resource "aws_secretsmanager_secret_version" "gis_hars_file_host" {
+  secret_id     = aws_secretsmanager_secret.gis_hars_file_host.id
+  secret_string = "changeme"
+}
+
 resource "aws_secretsmanager_secret_version" "rds_credentials" {
   secret_id     = aws_secretsmanager_secret.gis_proxy_user.id
   secret_string = <<EOF


### PR DESCRIPTION
Previously, the file hosts were hardcoded into the glassfish-resources file. This change allows them to be pulled from AWS Secrets Manager. Additional changes can be added to this pull request to parameterize other values as needed.