### PR TITLE
hotfix changes the criteria of a "missing" SIN or Client ID. 

### DIFF
--- a/gis/GIS-war/src/main/java/giswar/batch/GisEntry.java
+++ b/gis/GIS-war/src/main/java/giswar/batch/GisEntry.java
@@ -83,7 +83,7 @@ public class GisEntry{
 
     public void setAccountId(String clientID, String SIN, IDatabase db, DataSource ds) {
         // Populate SIN if it exists
-        if (SIN != null && SIN.matches("\\d{9}")){
+        if (SIN != null && SIN != "000000000") {
             this.accountId = SIN;
             setAccountCode("S");
         } else {
@@ -123,7 +123,7 @@ public class GisEntry{
                 // if account code is "O" then its an OAS account
                 if(resultSet.get(0)[7].equals("O")){
                     // set accountId to clientID if it exists else 000000000000
-                    if(clientID != null && clientID.matches("\\d{12}")){
+                    if(clientID != null && clientID != "000000000000"){
                         this.accountId = clientID;
                     } else {
                         this.accountId = "000000000000";
@@ -132,7 +132,7 @@ public class GisEntry{
                 // if account code is "S" then its a SIN account
                 } else if(resultSet.get(0)[7].equals("S")){
                     // set accountId to SIN if it exists else 000000000
-                    if(resultSet.get(0)[2] != null && resultSet.get(0)[2].matches("\\d{9}")){
+                    if(resultSet.get(0)[2] != null && resultSet.get(0)[2] != "000000000"){
                         this.accountId = resultSet.get(0)[2];
                     } else {
                         this.accountId = "000000000";
@@ -141,7 +141,7 @@ public class GisEntry{
                 // if account code is "A" then its an IA account
                 } else {
                     // set accountId to IA account id if it exists else 000000000
-                    if(resultSet.get(0)[2] != null && resultSet.get(0)[2].matches("\\d{9}")){
+                    if(resultSet.get(0)[2] != null && resultSet.get(0)[2] != "000000000"){
                         this.accountId = resultSet.get(0)[2];
                     } else {
                         this.accountId = "000000000";
@@ -150,7 +150,7 @@ public class GisEntry{
                 }
             } else {
                 // if no matching client is found then we assume its a new OAS account so we set accountId to clientID if it exists else 000000000000
-                if(clientID != null && clientID.matches("\\d{12}")){
+                if(clientID != null && clientID != "000000000000"){
                     this.accountId = clientID;
                 } else {
                     this.accountId = "000000000000";


### PR DESCRIPTION
Previously it was assumed "missing" would be defined as empty string but instead missing is an entry of all 0s. This change alters the criteria measuring if SIN or client id are missing.